### PR TITLE
Remove rarian dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 pi-package (0.6) buster; urgency=medium
 
   * Italian translation updated
+  * Remove rarian dependency
 
  -- Simon Long <simon@raspberrypi.com>  Tue, 28 Apr 2020 10:11:03 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Build-Depends: debhelper (>= 9.0.0),
                libpolkit-gobject-1-dev,
                libsystemd-dev [linux-any],
                python-dev,
-               rarian-compat,
                xmlto,
                yelp-tools
 Standards-Version: 3.9.6


### PR DESCRIPTION
Rarian no longer ships with Buster, so this package fails to build for i386.

https://packages.debian.org/search?suite=buster&searchon=names&keywords=rarian-compat

Removing the dependency doesn't seem to cause any issues.

