### PR TITLE
Correct package conflicts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Depends: pi-package-session (>= ${source:Version}),
          ${shlibs:Depends},
          libgtk-3-0 (>= 3.16.0)
 Provides: update-notifier
-Conflicts: gnome-software, gnome-packagekit
+Conflicts: gnome-packagekit-data, packagekit
 Description: Graphical distribution neutral package manager for GNOME
  PackageKit allows performing simple software management tasks over a DBus
  interface  e.g. refreshing the cache, updating, installing and removing

--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,7 @@ Depends: pi-package-data (>= ${source:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Suggests: pi-package
-Conflicts: gnome-software, gnome-packagekit
+Conflicts: gnome-packagekit-data, packagekit
 Description: Provides PackageKit session API for GNOME
  PackageKit allows performing simple software management tasks over a DBus
  interface  e.g. refreshing the cache, updating, installing and removing
@@ -59,7 +59,7 @@ Package: pi-package-data
 Architecture: all
 Depends: ${misc:Depends},
          libgtk-3-0 (>= 3.16.0)
-Conflicts: gnome-software, gnome-packagekit
+Conflicts: gnome-packagekit-data, packagekit
 Description: Data files for GNOME-PackageKit
  PackageKit allows performing simple software management tasks over a DBus
  interface  e.g. refreshing the cache, updating, installing and removing


### PR DESCRIPTION
Over at Pi-Apps we have received multiple bug reports from real users experiencing pi-package causing file conflicts and other dpkg failures. [The issue](https://github.com/raspberrypi-ui/pipackage/issues/7) I opened ended with the wrong package being added to the conflicts list, which does not really solve the problem here but instead makes my job harder. My apologies for not having the full picture at the time and incorrectly stating the root source of the conflict in that earlier issue I opened.

I'm hoping that this can get merged and pushed to the Bullseye and Bookworm repos at a minimum. Otherwise one of us at Pi-Apps will be forced to implement a workaround to solve this problem the brute-force way - which is undesirable on our end, a disappointment on the users' end, and completely solvable on your end.